### PR TITLE
Add support for reading from stdin

### DIFF
--- a/src/main/scala/lazabs/Main.scala
+++ b/src/main/scala/lazabs/Main.scala
@@ -30,7 +30,7 @@
 
 package lazabs
 
-import java.io.{FileInputStream,InputStream,FileNotFoundException}
+import java.io.{InputStream, FileNotFoundException, Reader, FileReader, BufferedReader, File}
 import parser._
 import lazabs.art._
 import lazabs.art.SearchMethod._
@@ -73,7 +73,7 @@ object GlobalParameters {
 }
 
 class GlobalParameters extends Cloneable {
-  var in: InputStream = null
+  var in: Reader = null
   var fileName = ""
   var funcName = "main"
   var solFileName = ""
@@ -292,16 +292,16 @@ object Main {
 
   def setInputToSTDIN {
     val params = GlobalParameters.parameters.value
-    params.in = System.in
+    params.in = new BufferedReader(Console.in)
     params.format = 
       if (params.format == GlobalParameters.InputFormat.AutoDetect) 
         GlobalParameters.InputFormat.SMTHorn 
       else params.format
   }
 
-  def getFileStream(fileName : String) : InputStream = {
+  def getFileStream(fileName : String) : Reader = {
     try {
-      new FileInputStream(fileName)
+      new BufferedReader(new FileReader(new File(fileName)))
     } catch {
       case _: FileNotFoundException => throw FileOrOptionNotFoundException(fileName)
       case e: Throwable => throw e

--- a/src/main/scala/lazabs/Main.scala
+++ b/src/main/scala/lazabs/Main.scala
@@ -292,7 +292,10 @@ object Main {
   def setInputToSTDIN {
     val params = GlobalParameters.parameters.value
     params.in = System.in
-    params.format = GlobalParameters.InputFormat.SMTHorn
+    params.format = 
+      if (params.format == GlobalParameters.InputFormat.AutoDetect) 
+        GlobalParameters.InputFormat.SMTHorn 
+      else params.format
   }
 
   def getFileStream(fileName : String) : InputStream = {

--- a/src/main/scala/lazabs/Main.scala
+++ b/src/main/scala/lazabs/Main.scala
@@ -281,6 +281,7 @@ object Main {
   class MainException(msg : String) extends Exception(msg)
   object TimeoutException extends MainException("timeout")
   object StoppedException extends MainException("stopped")
+  case class FileOrOptionNotFoundException(fileName: String) extends MainException(s"No such file or option: $fileName . Use -h for usage information")
   object PrintingFinishedException extends Exception
 
   def openInputFile {
@@ -302,9 +303,8 @@ object Main {
     try {
       new FileInputStream(fileName)
     } catch {
-      case e: FileNotFoundException =>
-        throw new MainException("No such file or option: " + fileName + ". Use -h for usage information" )
-        sys.exit(0)
+      case _: FileNotFoundException => throw FileOrOptionNotFoundException(fileName)
+      case e: Throwable => throw e
     }
   }
 

--- a/src/main/scala/lazabs/horn/parser/HornReader.scala
+++ b/src/main/scala/lazabs/horn/parser/HornReader.scala
@@ -30,7 +30,7 @@
 
 package lazabs.horn.parser
 
-import java.io.{FileInputStream,InputStream,FileNotFoundException}
+import java.io.{FileInputStream, InputStream, FileNotFoundException, Reader, BufferedReader, FileReader, File}
 
 import lazabs.horn.global._
 import lazabs.prover.PrincessWrapper
@@ -58,9 +58,8 @@ import scala.collection.mutable.{HashMap => MHashMap, ArrayBuffer,
                                  HashSet => MHashSet, LinkedHashSet}
 
 object HornReader {
-  def apply(inputStream: InputStream): Seq[HornClause] = {
-    val in = new java.io.BufferedReader(new java.io.InputStreamReader(inputStream))
-    val lexer = new HornLexer(in)
+  def apply(inputStream: Reader): Seq[HornClause] = {
+    val lexer = new HornLexer(inputStream)
     val parser = new Parser(lexer)
     val tree = parser.parse()
     (scala.collection.JavaConversions.asScalaBuffer(
@@ -68,11 +67,11 @@ object HornReader {
   }
 
   def fromSMT(fileName: String) : Seq[HornClause] = {
-    val inputStream = new java.io.FileInputStream(fileName)
+    val inputStream = new BufferedReader(new FileReader(new File(fileName)))
     fromSMT(inputStream)
   }
 
-  def fromSMT(inputStream: InputStream) : Seq[HornClause] = {
+  def fromSMT(inputStream: Reader) : Seq[HornClause] = {
     SimpleAPI.withProver(enableAssert = lazabs.Main.assertions) { p =>
       (new SMTHornReader(inputStream, p)).result
     }
@@ -232,7 +231,7 @@ object HornReader {
 ////////////////////////////////////////////////////////////////////////////////
 
 class SMTHornReader protected[parser] (
-         inputStream: InputStream,
+         inputStream: Reader,
          // we need a prover for some of the
          // clause preprocessing, in general
          p : SimpleAPI) {
@@ -252,8 +251,7 @@ class SMTHornReader protected[parser] (
       "---------------------------------- Parsing -------------------------------------")
   }
 
-  private val reader = new java.io.BufferedReader (
-                 new java.io.InputStreamReader(inputStream))
+  private val reader = new BufferedReader(inputStream)
   private val settings = Param.BOOLEAN_FUNCTIONS_AS_PREDICATES.set(
                    ParserSettings.DEFAULT, true)
 

--- a/src/main/scala/lazabs/horn/parser/HornReader.scala
+++ b/src/main/scala/lazabs/horn/parser/HornReader.scala
@@ -58,9 +58,8 @@ import scala.collection.mutable.{HashMap => MHashMap, ArrayBuffer,
                                  HashSet => MHashSet, LinkedHashSet}
 
 object HornReader {
-  def apply(fileName: String): Seq[HornClause] = {
-    val in = new java.io.BufferedReader (
-                 new java.io.FileReader(fileName))
+  def apply(inputStream: InputStream): Seq[HornClause] = {
+    val in = new java.io.BufferedReader(new java.io.InputStreamReader(inputStream))
     val lexer = new HornLexer(in)
     val parser = new Parser(lexer)
     val tree = parser.parse()
@@ -68,10 +67,16 @@ object HornReader {
        tree.value.asInstanceOf[java.util.List[HornClause]]))
   }
 
-  def fromSMT(fileName: String) : Seq[HornClause] =
+  def fromSMT(fileName: String) : Seq[HornClause] = {
+    val inputStream = new java.io.FileInputStream(fileName)
+    fromSMT(inputStream)
+  }
+
+  def fromSMT(inputStream: InputStream) : Seq[HornClause] = {
     SimpleAPI.withProver(enableAssert = lazabs.Main.assertions) { p =>
-      (new SMTHornReader(fileName, p)).result
+      (new SMTHornReader(inputStream, p)).result
     }
+  }
 
   //////////////////////////////////////////////////////////////////////////////
 
@@ -227,7 +232,7 @@ object HornReader {
 ////////////////////////////////////////////////////////////////////////////////
 
 class SMTHornReader protected[parser] (
-         fileName: String,
+         inputStream: InputStream,
          // we need a prover for some of the
          // clause preprocessing, in general
          p : SimpleAPI) {
@@ -248,7 +253,7 @@ class SMTHornReader protected[parser] (
   }
 
   private val reader = new java.io.BufferedReader (
-                 new java.io.FileReader(new java.io.File (fileName)))
+                 new java.io.InputStreamReader(inputStream))
   private val settings = Param.BOOLEAN_FUNCTIONS_AS_PREDICATES.set(
                    ParserSettings.DEFAULT, true)
 

--- a/src/main/scala/lazabs/nts/NtsWrapper.scala
+++ b/src/main/scala/lazabs/nts/NtsWrapper.scala
@@ -58,13 +58,8 @@ object NtsWrapper {
   /**
    * returns the NTS system
    */
-  def apply(ntsFileName: String): Nts = {
-    val is: InputStream = try {
-      new FileInputStream(ntsFileName)
-    } catch {
-      case e: FileNotFoundException => println("No such file or option: " + ntsFileName + ". Use -h for usage information" )
-        sys.exit(0)
-    }
+  def apply(inputStream: InputStream): Nts = {
+    val is: InputStream = inputStream
     val listen: ParserListener = new ParserListener
     NTSParser.parseNTS(is, listen)
     val nts:NTS = listen.nts

--- a/src/main/scala/lazabs/nts/NtsWrapper.scala
+++ b/src/main/scala/lazabs/nts/NtsWrapper.scala
@@ -58,8 +58,8 @@ object NtsWrapper {
   /**
    * returns the NTS system
    */
-  def apply(inputStream: InputStream): Nts = {
-    val is: InputStream = inputStream
+  def apply(inputStream: Reader): Nts = {
+    val is = new InputStream { def read(): Int = inputStream.read() }
     val listen: ParserListener = new ParserListener
     NTSParser.parseNTS(is, listen)
     val nts:NTS = listen.nts


### PR DESCRIPTION
As title says, modified the main file and some associated parser calls to use `InputStream` instead. 

Factorized creation of the input stream from the file name into a function to have a uniform process and error. 

Added CLI option `-in` (like z3) to allow reading files from standard input. This defaults to SMT Horn input format if no other has been given yet. (Since the format cannot be determined from file name).

As with most other options, if you later provide a file name in the argument list, it will override `-in`.

I needed this while trying to interface with Eldarica via [scala-smtlib](https://github.com/epfl-lara/scala-smtlib) (to reuse some solver interfaces instead of using the Eldarica Scala API).

I think it is a good thing to have, in any case.

As to why the PR is draft, I tested the stdin input in three ways:

1. Providing a file, e.g. `./eld -in < file` --- this works well as expected
2. Typing manually (less interesting, but still), e.g. `./eld -in` and simply typing the query. I had to press Ctrl-D multiples times before my EOF was accepted and the query processed. 
3. Using `run -in` from within `sbt`. This did not work at all. Eldarica immediately outputs `sat` corresponding to the empty input stream. 

I will try to investigate situations 2 and 3 before un-marking the PR as draft. That, and more testing. 

Till then, happy to take any feedback, especially as it is my first PR for this project.