### PR TITLE
Porting to Scala 2.13.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,7 @@ lazy val commonSettings = Seq(
     version := "2.0.9",
     homepage := Some(url("https://github.com/uuverifiers/eldarica")),
     licenses := Seq("BSD License 2.0" -> url("https://github.com/uuverifiers/eldarica/blob/master/LICENSE")),
-    scalaVersion := "2.11.12",
-    crossScalaVersions := Seq("2.11.12", "2.12.18"),
+    scalaVersion := "2.13.12",
     run / fork := true,
     cancelable in Global := true,
     publishTo := Some(Resolver.file("file",  new File( "/home/wv/public_html/maven/" )) )
@@ -126,12 +125,13 @@ lazy val root = (project in file(".")).
     scalacOptions += (scalaVersion map { sv => sv match {
       case "2.11.12" => "-optimise"
       case "2.12.18" => "-opt:_"
+      case "2.13.12" => "-opt:_"
     }}).value,
 //
     assembly / test := None,
 //
     libraryDependencies +=
-      "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+      "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
 //
     libraryDependencies +=
       "net.sf.squirrel-sql.thirdparty-non-maven" % "java-cup" % "0.11a",
@@ -140,13 +140,13 @@ lazy val root = (project in file(".")).
       "org.antlr" % "antlr" % "3.3",
 //
     libraryDependencies +=
-      "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
+      "org.scala-lang.modules" %% "scala-xml" % "1.3.1",
 //
     libraryDependencies +=
-      "org.scalactic" %% "scalactic" % "3.2.14",
+      "org.scalactic" %% "scalactic" % "3.2.17",
 //
     libraryDependencies +=
-      "org.scalatest" %% "scalatest" % "3.2.14" % "test",
+      "org.scalatest" %% "scalatest" % "3.2.17" % "test",
 //
 //    libraryDependencies += "io.github.uuverifiers" %% "princess" % "2023-04-07"
 //

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.7

--- a/src/main/scala/lazabs/ast/ASTree.scala
+++ b/src/main/scala/lazabs/ast/ASTree.scala
@@ -32,6 +32,8 @@ package lazabs.ast
 import lazabs.types._
 import ap.theories.{ADT, Heap, Theory, TheoryCollector, TheoryRegistry}
 
+import scala.jdk.CollectionConverters._
+
 
 object ASTree {
   sealed abstract class ASTree extends ScalaType
@@ -648,13 +650,13 @@ object ASTree {
   // helper method
   def expandPreds(p: Predicate): java.util.List[Predicate] = p match {
     case Predicate(Block(pred), children) =>
-      scala.collection.JavaConversions.seqAsJavaList(pred.map(p => {
+      pred.map(p => {
         if(!p.isInstanceOf[Expression]) {
           throw new Exception("Nested predicates are required to be expressions: " + p)
         }
         Predicate(p.asInstanceOf[Expression], children)
-      }))
-    case _ => scala.collection.JavaConversions.seqAsJavaList(List(p))
+      }).asJava
+    case _ => List(p).asJava
   }
   
 }

--- a/src/main/scala/lazabs/cfg/MakeCFG.scala
+++ b/src/main/scala/lazabs/cfg/MakeCFG.scala
@@ -182,7 +182,7 @@ object MakeCFG {
         aTrans = (addMultiMap(aTrans,Map(to -> (aTrans.getOrElse(aStart, Set.empty)))) - aStart).mapValues(s => s.map(adj => adj match {
           case CFGAdjacent(adjLabel, adjTo) if (aFinish == adjTo) => CFGAdjacent(adjLabel, to)
           case _ => adj
-        }))
+        })).toMap
         predMap = predMap - aStart - aFinish
         varsMap = varsMap - aStart - aFinish
         trans = addMultiMap(trans,aTrans)
@@ -213,7 +213,7 @@ object MakeCFG {
           aTrans = (addMultiMap(aTrans,Map(actorStartVertex -> (aTrans.getOrElse(aStart, Set.empty)))) - aStart).mapValues(s => s.map(adj => adj match {
             case CFGAdjacent(adjLabel, adjTo) if (aFinish == adjTo) => CFGAdjacent(adjLabel, to)
             case _ => adj
-            }))
+            })).toMap
           predMap = predMap - aStart - aFinish
           varsMap = varsMap - aStart - aFinish
           trans = addMultiMap(trans,aTrans)
@@ -448,7 +448,7 @@ object MakeCFG {
             atomicTrans = atomicTrans.mapValues(s => s.map(adj => adj match {
               case CFGAdjacent(adjLabel, adjTo) if (adjTo == atomicFinishVertex) => CFGAdjacent(adjLabel, atomicFinishVertexWithPredicates)
               case _ => adj
-            }))
+            })).toMap
             val currentVertex1  = CFGVertex(FreshCFGStateId.apply)
             val currentVertex2  = CFGVertex(FreshCFGStateId.apply)
             val finishVertex  = CFGVertex(FreshCFGStateId.apply)

--- a/src/main/scala/lazabs/horn/abstractions/AbsLattice.scala
+++ b/src/main/scala/lazabs/horn/abstractions/AbsLattice.scala
@@ -577,7 +577,7 @@ class ProductLattice[A <: AbsLattice, B <: AbsLattice] private (val a : A, val b
 
       def hasNext = aPeek.hasNext || bPeek.hasNext
 
-      def next =
+      def next() =
         if (aPeek.hasNext) {
           if (bPeek.hasNext &&
               a.cost(aPeek.peekNext) + bCost > aCost + b.cost(bPeek.peekNext)) {
@@ -602,7 +602,7 @@ class ProductLattice[A <: AbsLattice, B <: AbsLattice] private (val a : A, val b
 
     def hasNext = aIt.hasNext || bIt.hasNext
 
-    def next =
+    def next() =
       if (!aIt.hasNext)
         (x._1, bIt.next)
       else if (!bIt.hasNext)
@@ -729,8 +729,9 @@ abstract class BitSetLattice(width : Int, val name : String) extends AbsLattice 
             (implicit randGen : Random) : LatticeObject = {
     val nelem = for (x <- upper;
                      if ( (lower contains x) || randGen.nextInt(100) < 80)) yield x
-    assert(latticeOrder.lteq(bottom, nelem))
-    nelem
+    val bitset = BitSet.fromSpecific(nelem)
+    assert(latticeOrder.lteq(bottom, bitset))
+    bitset
   }
 
   def cost(obj : LatticeObject) : Int =
@@ -764,7 +765,7 @@ abstract class BitSetLattice(width : Int, val name : String) extends AbsLattice 
 
     def hasNext = !remaining.isEmpty
 
-    def next = {
+    def next() = {
       val selected =
         if (remaining.size > 1) {
           val it = remaining.iterator

--- a/src/main/scala/lazabs/horn/abstractions/AbsReader.scala
+++ b/src/main/scala/lazabs/horn/abstractions/AbsReader.scala
@@ -145,7 +145,7 @@ class AbsReader(input : java.io.Reader) {
 
   /** Implicit conversion so that we can get a Scala-like iterator from a
    * a Java list */
-  import scala.collection.JavaConversions.{asScalaBuffer, asScalaIterator}
+  import scala.jdk.CollectionConverters._
 
   /**
    * Translation of sorts to the SMT parser types.
@@ -167,7 +167,7 @@ class AbsReader(input : java.io.Reader) {
       case s : CompositeSort => s.identifier_ match {
         case id : SymbolIdent => (printer print id) match {
           case "Array" => {
-            val args = s.listsort_.toList map translateSort
+            val args = s.listsort_.asScala.toList.map(translateSort _)
             if (args.size < 2)
               throw new Exception(
                 "Expected at least two sort arguments in Array sort")
@@ -216,7 +216,7 @@ class AbsReader(input : java.io.Reader) {
       val predref = predrefC.asInstanceOf[PredRef]
       val predName = translateSymbolRef(predref.symbolref_)
 
-      for (variableC <- predref.listsortedvariablec_.reverseIterator) {
+      for (variableC <- predref.listsortedvariablec_.asScala.reverseIterator) {
         val variable = variableC.asInstanceOf[SortedVariable]
         val t = SMTParser2InputAbsy.BoundVariable(translateSort(variable.sort_))
         env.pushVar(printer print variable.symbol_, t)
@@ -246,12 +246,12 @@ class AbsReader(input : java.io.Reader) {
 
     val initialPredicates : List[(String, Seq[IFormula])] =
     (for (predspec <-
-            specC.asInstanceOf[Spec].listpredspec_.iterator;
+            specC.asInstanceOf[Spec].listpredspec_.asScala;
           if (predspec.isInstanceOf[InitialPredicates]);
           initPreds = predspec.asInstanceOf[InitialPredicates]) yield {
        val (predName, varNum) = translatePredRef(initPreds.predrefc_)
 
-       val preds = (for (term <- initPreds.listterm_.iterator) yield {
+       val preds = (for (term <- initPreds.listterm_.asScala) yield {
          parseExpr(printer print term).asInstanceOf[IFormula]
        }).toList
 
@@ -268,14 +268,14 @@ class AbsReader(input : java.io.Reader) {
 
     val templateHints : List[(String, Seq[VerifHintElement])] =
     (for (predspec <-
-            specC.asInstanceOf[Spec].listpredspec_.iterator;
+            specC.asInstanceOf[Spec].listpredspec_.asScala;
           if (predspec.isInstanceOf[Templates]);
           templates = predspec.asInstanceOf[Templates]) yield {
        val (predName, varNum) = translatePredRef(templates.predrefc_)
 
        val hints = new ArrayBuffer[VerifHintElement]
 
-       for (templatec <- templates.listtemplatec_)
+       for (templatec <- templates.listtemplatec_.asScala)
          templatec match {
            case template : TermTemplate => {
              val expr = parseExpr(printer print template.term_)

--- a/src/main/scala/lazabs/horn/abstractions/LoopDetector.scala
+++ b/src/main/scala/lazabs/horn/abstractions/LoopDetector.scala
@@ -191,11 +191,11 @@ class LoopDetector(clauses : Seq[HornClauses.Clause]) {
 
        val lattices : List[AbsLattice] =
          (if (preds.isEmpty) List()
-          else List(PredicateLattice(preds, head.name))) ++
+          else List(PredicateLattice(preds.toSeq, head.name))) ++
          (if (terms.isEmpty) List()
-          else List(TermSubsetLattice(terms, head.name))) ++
+          else List(TermSubsetLattice(terms.toSeq, head.name))) ++
          (if (ineqs.isEmpty) List()
-          else List(TermIneqLattice(ineqs, head.name)))
+          else List(TermIneqLattice(ineqs.toSeq, head.name)))
 
        val latt = lattices reduceLeft (ProductLattice(_, _, true))
 

--- a/src/main/scala/lazabs/horn/abstractions/VerificationHints.scala
+++ b/src/main/scala/lazabs/horn/abstractions/VerificationHints.scala
@@ -154,7 +154,7 @@ object VerificationHints {
 
     def filterPredicates(remainingPreds : GSet[IExpression.Predicate]) = {
       val remHints = predicateHints filterKeys remainingPreds
-      VerificationHints(remHints)
+      VerificationHints(remHints.toMap)
     }
 
     def filterNotPredicates(removed : GSet[IExpression.Predicate]) =
@@ -225,7 +225,7 @@ object VerificationHints {
   class InitPredicateVerificationHints(preds : Map[Predicate, Seq[IFormula]])
         extends VerificationHints {
     import VerificationHints._
-    val predicateHints = preds mapValues { l => l map (VerifHintInitPred(_)) }
+    val predicateHints = preds.mapValues(l => l map (VerifHintInitPred(_))).toMap
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/main/scala/lazabs/horn/acceleration/HornAccelerate.scala
+++ b/src/main/scala/lazabs/horn/acceleration/HornAccelerate.scala
@@ -80,8 +80,8 @@ class DepGraph(orig : Seq[HornClauses.Clause]) extends AbsGraph {
     (s,orig,p2n,triple2e)
   } 
   
-  override def nodes() : Iterable[Node] = n.values
-  override def edges() : Iterable[Edge] = e.values
+  override def nodes : Iterable[Node] = n.values
+  override def edges : Iterable[Edge] = e.values
   
   override def filterPrefix(pref : Seq[Edge]) : Boolean = {
     val c = HornManipulate.inlineSequence(pref.map(_.c))

--- a/src/main/scala/lazabs/horn/bottomup/AbstractState.scala
+++ b/src/main/scala/lazabs/horn/bottomup/AbstractState.scala
@@ -112,7 +112,7 @@ import Util._
       birthTime
     }
 
-    private implicit val ord = new Ordering[Expansion] {
+    private implicit val ord: Ordering[Expansion] = new Ordering[Expansion] {
       def compare(s : Expansion, t : Expansion) =
         priority(t) - priority(s)
     }

--- a/src/main/scala/lazabs/horn/bottomup/CEGAR.scala
+++ b/src/main/scala/lazabs/horn/bottomup/CEGAR.scala
@@ -466,7 +466,7 @@ class CEGAR[CC <% HornClauses.ConstraintClause]
 
     val (remainingExp, reactivatedExp) =
       postponedExpansions partition (_._1 exists (backwardSubsumedStates contains _))
-    postponedExpansions reduceToSize 0
+    postponedExpansions.clearAndShrink(remainingExp.size)
     postponedExpansions ++= remainingExp
 
     for (exp <- reactivatedExp)
@@ -503,7 +503,7 @@ class CEGAR[CC <% HornClauses.ConstraintClause]
 
       } else {
 
-        implicit val _ = clause.order
+        implicit val _order: TermOrder = clause.order
 
         val initialAssumptions =
           sf.reduce(conj(List(clause.constraint) ++ (state instances occ)))
@@ -532,7 +532,7 @@ class CEGAR[CC <% HornClauses.ConstraintClause]
                         fixedIndex : Int, occ : Int,
                         byStates : Array[Seq[AbstractState]]) : Unit = {
     import TerForConvenience._
-    implicit val _ = clause.order
+    implicit val _order: TermOrder = clause.order
 
     val NormClause(constraint, body, head) = clause
 
@@ -564,7 +564,7 @@ class CEGAR[CC <% HornClauses.ConstraintClause]
                            fixedIndex : Int, occ : Int,
                            byStates : Array[Seq[AbstractState]]) : Unit = {
     import TerForConvenience._
-    implicit val _ = clause.order
+    implicit val _order: TermOrder = clause.order
 
     val NormClause(constraint, body, head) = clause
 
@@ -707,7 +707,7 @@ class CEGAR[CC <% HornClauses.ConstraintClause]
        } else {
          val flags = createBooleanVariables(activeAbstractStates(brs).size)
 
-         implicit val _ = order
+         order: TermOrder order
          addAssertion(
            disj(for ((s, IAtom(p, _)) <-
                        activeAbstractStates(brs).iterator zip flags.iterator)
@@ -748,7 +748,7 @@ class CEGAR[CC <% HornClauses.ConstraintClause]
     val remainingEdges = for (e@AbstractEdge(from, to, _, _) <- abstractEdges;
                               if (from forall reachable))
                          yield e
-    abstractEdges reduceToSize 0
+    abstractEdges.clearAndShrink(remainingEdges.size)
     abstractEdges ++= remainingEdges
     
     for ((_, preds) <- activeAbstractStates)
@@ -764,7 +764,7 @@ class CEGAR[CC <% HornClauses.ConstraintClause]
       for (exp@(from, _, _, _) <- postponedExpansions;
            if (from forall reachable))
       yield exp
-    postponedExpansions reduceToSize 0
+    postponedExpansions.clearAndShrink(remainingPostponedExpansions.size)
     postponedExpansions ++= remainingPostponedExpansions
 
     // Previously subsumed states might become relevant again

--- a/src/main/scala/lazabs/horn/bottomup/DisjInterpolator.scala
+++ b/src/main/scala/lazabs/horn/bottomup/DisjInterpolator.scala
@@ -51,6 +51,7 @@ import SimpleAPI.ProverStatus
 
 import scala.collection.mutable.{HashMap => MHashMap, HashSet => MHashSet,
                                  LinkedHashMap, ArrayBuffer}
+import ap.terfor.RichPredicate
 
 object DisjInterpolator {
 
@@ -227,10 +228,10 @@ object DisjInterpolator {
       }
 
       def flag2Conj(f : IFormula) : Conjunction = {
-        implicit val _ = order
+        implicit val _order: TermOrder = order
         import TerForConvenience._
         f match {
-          case IAtom(p, Seq()) => p(List())
+          case IAtom(p, Seq()) => p(Seq.empty)
         }
       }
 
@@ -853,7 +854,7 @@ object DisjInterpolator {
                     o, o + sharedHeadLits(sharedInd).predicate.arity)
                 }
               }
-              clause.instantiateConstraint(newHeadArgs, newBodyArgs,
+              clause.instantiateConstraint(newHeadArgs, newBodyArgs.toSeq.map(_.toSeq),
                                            localVariables, sig)
             }
           }
@@ -875,11 +876,11 @@ object DisjInterpolator {
                                     localVariables : Seq[ConstantTerm],
                                     sig : Signature) = {
             import TerForConvenience._
-            implicit val _ = sig.order
+            implicit val _order: TermOrder = sig.order
             val tempPredArgs = bodyArguments.head
             (headArguments === tempPredArgs.take(headArguments.size)) & conj(
                 for ((args, o) <- bodyArguments.tail zip tempPredArgOffsets)
-                yield (args === tempPredArgs.view(o, o + args.size)))
+                yield (args === tempPredArgs.view(o, o + args.size).toSeq))
           }
         }
 
@@ -910,7 +911,7 @@ object DisjInterpolator {
       }
     }
 
-    (dag, localPreds)
+    (dag, localPreds.toSeq)
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -961,7 +962,7 @@ object DisjInterpolator {
         if (headLit.predicate != FALSE)
           order = order extendPred pred
 
-        implicit val _ = order
+        implicit val _order: TermOrder = order
         import TerForConvenience._
         freshRelSyms.put(i, Atom(pred, for (c <- args) yield l(c), order))
       }
@@ -1056,7 +1057,7 @@ object DisjInterpolator {
                                    ("%04d".format(benchmarkCounter)) + ".smt2")
     benchmarkCounter = benchmarkCounter + 1
     Console.withOut(benchmarkFile) {
-      SMTLineariser(clauseFormulas,
+      SMTLineariser(clauseFormulas.toSeq,
                     Signature(Set(), Set(), Set(), order restrict Set()),
                     "HORN",
                     solvable match {

--- a/src/main/scala/lazabs/horn/bottomup/Hasher.scala
+++ b/src/main/scala/lazabs/horn/bottomup/Hasher.scala
@@ -152,7 +152,7 @@ class Hasher(globalOrder : TermOrder, reducerSettings : ReducerSettings)
 
   import Hasher._
   import IHasher._
-  private implicit val _globalOrder = globalOrder
+  private implicit val _globalOrder: TermOrder = globalOrder
 
   private val watchedFormulas = new ArrayBuffer[Conjunction]
   private val evalVectors     = new ArrayBuffer[MBitSet]
@@ -364,7 +364,7 @@ class Hasher(globalOrder : TermOrder, reducerSettings : ReducerSettings)
       assertionStack(i) match {
         case AssertionFrame(vec) => {
           currentEvalVector = vec
-          assertionStack reduceToSize i
+          assertionStack.remove(i, assertionStack.size - i)
           return
         }
         case _ =>
@@ -372,6 +372,7 @@ class Hasher(globalOrder : TermOrder, reducerSettings : ReducerSettings)
       }
       i = i - 1
     }
+    assertionStack.trimToSize()
   }
 
   def scope[A](comp : => A) : A = {

--- a/src/main/scala/lazabs/horn/bottomup/HornClauses.scala
+++ b/src/main/scala/lazabs/horn/bottomup/HornClauses.scala
@@ -279,8 +279,8 @@ object HornClauses {
     }
   }
 
-  implicit def toPrologSyntax(f : IFormula) = new PrologApplier(!f)
-  implicit def toPrologSyntax(b : Boolean)  = new PrologApplier(!b)
+  implicit def toPrologSyntax(f : IFormula): PrologApplier = new PrologApplier(!f)
+  implicit def toPrologSyntax(b : Boolean): PrologApplier  = new PrologApplier(!b)
 
   //////////////////////////////////////////////////////////////////////////////
 

--- a/src/main/scala/lazabs/horn/bottomup/HornPredAbs.scala
+++ b/src/main/scala/lazabs/horn/bottomup/HornPredAbs.scala
@@ -71,7 +71,7 @@ object HornPredAbs {
   
   //////////////////////////////////////////////////////////////////////////////
 
-  implicit def normClause2ConstraintClause(nc : NormClause) = {
+  implicit def normClause2ConstraintClause(nc : NormClause): ConstraintClause = {
     val NormClause(_, bodyLits, (RelationSymbol(headPred), _)) = nc
 
     new ConstraintClause {

--- a/src/main/scala/lazabs/horn/bottomup/HornPredAbsContext.scala
+++ b/src/main/scala/lazabs/horn/bottomup/HornPredAbsContext.scala
@@ -189,7 +189,7 @@ class HornPredAbsContextImpl[CC <% HornClauses.ConstraintClause]
   if (useHashing)
     println("State hashing enabled")
 
-  implicit val sf = new SymbolFactory(theories)
+  implicit val sf: SymbolFactory = new SymbolFactory(theories)
 
   val relationSymbols = {
     val preds =
@@ -259,7 +259,7 @@ class HornPredAbsContextImpl[CC <% HornClauses.ConstraintClause]
         (normClauses groupBy { c => c._1.body.size }).toList sortBy (_._1))
     println("   " + clauses.size + " clauses with " + num + " body literals")
 
-  val relationSymbolOccurrences = computeRSOccurrences
+  val relationSymbolOccurrences = computeRSOccurrences.toMap
 
   val goalSettings = {
     var gs = GoalSettings.DEFAULT

--- a/src/main/scala/lazabs/horn/bottomup/HornWrapper.scala
+++ b/src/main/scala/lazabs/horn/bottomup/HornWrapper.scala
@@ -548,7 +548,7 @@ class InnerHornWrapper(unsimplifiedClauses : Seq[Clause],
               // only keep relation symbols that were also part of the orginal problem
               res filterKeys allPredicates(unsimplifiedClauses)
             }
-          }
+          }.toMap
 
         val r = Left(solFun _)
 

--- a/src/main/scala/lazabs/horn/bottomup/IncrementalHornPredAbs.scala
+++ b/src/main/scala/lazabs/horn/bottomup/IncrementalHornPredAbs.scala
@@ -98,7 +98,7 @@ class IncrementalHornPredAbs
       if (lazabs.GlobalParameters.get.log)
         println("Testing substitution, remaining clauses: " + normClauses.size)
 
-      override val relationSymbolOccurrences = computeRSOccurrences
+      override val relationSymbolOccurrences = computeRSOccurrences.toMap
       override val hasher                    = createHasher
       override val clauseHashIndexes         = computeClauseHashIndexes
 

--- a/src/main/scala/lazabs/horn/bottomup/IntervalPropagator.scala
+++ b/src/main/scala/lazabs/horn/bottomup/IntervalPropagator.scala
@@ -65,7 +65,7 @@ object IntervalPropagator {
       case _ => {
         // replace c with a minimal constant in the ordering to extract
         // more information from the constraint
-        implicit val _ = order
+        implicit val _order: TermOrder = order
         import TerForConvenience._
         val newConstr =
           ReduceWithConjunction(c === smallConstant, order)(constr)
@@ -106,7 +106,7 @@ object IntervalPropagator {
   def toFormulas(c : ConstantTerm,
                  bounds : (Option[IdealInt], Option[IdealInt]),
                  order : TermOrder) : Iterator[Formula] = {
-    implicit val _ = order
+    implicit val _order: TermOrder = order
     import TerForConvenience._
 
     (for (b <- bounds._1.iterator) yield (c >= b)) ++

--- a/src/main/scala/lazabs/horn/bottomup/PredicateStore.scala
+++ b/src/main/scala/lazabs/horn/bottomup/PredicateStore.scala
@@ -279,7 +279,7 @@ class PredicateStore[CC <% HornClauses.ConstraintClause]
 
       impliedPreds.isEmpty || {
         import TerForConvenience._
-        implicit val _ = sf.order
+        implicit val order: TermOrder = sf.order
         val c = sf reduce conj(impliedPreds)
         !((sf reducer c)(f).isTrue)
       }

--- a/src/main/scala/lazabs/horn/bottomup/SymbolFactory.scala
+++ b/src/main/scala/lazabs/horn/bottomup/SymbolFactory.scala
@@ -84,7 +84,7 @@ object SymbolFactory {
 
     def order : TermOrder = {
       if (!constantsToAdd.isEmpty) {
-        orderVar = orderVar extend constantsToAdd
+        orderVar = orderVar extend constantsToAdd.toSeq
         constantsToAdd.clear
       }
       orderVar

--- a/src/main/scala/lazabs/horn/bottomup/TreeInterpolator.scala
+++ b/src/main/scala/lazabs/horn/bottomup/TreeInterpolator.scala
@@ -189,7 +189,7 @@ abstract class TreeInterpolator {
     if (lazabs.GlobalParameters.get.log)
       print(size(newProblem2))
 
-    (newProblem2, symbolTranslation, witnesses)
+    (newProblem2, symbolTranslation, witnesses.toSeq)
   }
 
   def propagateSymbols(problem : Tree[Conjunction], order : TermOrder)

--- a/src/main/scala/lazabs/horn/bottomup/Util.scala
+++ b/src/main/scala/lazabs/horn/bottomup/Util.scala
@@ -85,7 +85,7 @@ object Util {
     def subdagIterator = new Iterator[DagNode[D]] {
       private var rem = Dag.this
       def hasNext = DagEmpty != rem
-      def next = {
+      def next() = {
         val res = rem.asInstanceOf[DagNode[D]]
         rem = res.next
         res

--- a/src/main/scala/lazabs/horn/global/HornCegar.scala
+++ b/src/main/scala/lazabs/horn/global/HornCegar.scala
@@ -258,11 +258,11 @@ case class HornCegar(val originalConstraints: Seq[HornClause], val log: Boolean)
   def topolOrder: HashMap[ARGNode,Int] = {
     var result: HashMap[ARGNode,Int] = HashMap[ARGNode,Int]()
     
-    var inDegrees = (arg.transitions.map {
+    var inDegrees = ((arg.transitions.map {
       case (n,andTrans) => (for (relChild <- andTrans.map {
         case AndTransition(clause,children) => (for (r@RelVarNode(_,_,_) <- children.distinct) yield r)
       }.flatten) yield (relChild,n))
-    }.flatten.groupBy(_._1).mapValues(_.size)) ++ Map(arg.startNode -> 0) ++ (arg.or.values.flatten.map(dum => (dum,1))).toMap
+    }.flatten.groupBy(_._1).mapValues(_.size)).toMap ++ Map(arg.startNode -> 0) ++ (arg.or.values.flatten.map(dum => (dum,1))).toMap).toMap
         
     var current = 0
     while(!inDegrees.isEmpty) {
@@ -283,7 +283,7 @@ case class HornCegar(val originalConstraints: Seq[HornClause], val log: Boolean)
                 case None => throw new Exception("Error in topological ordering of the counter-example DAG")
               } 
           }
-          inDegrees -= node
+          inDegrees -= (node)
           current += 1
         case None =>
       }

--- a/src/main/scala/lazabs/horn/parser/HornParser.cup
+++ b/src/main/scala/lazabs/horn/parser/HornParser.cup
@@ -178,7 +178,7 @@ HornClauses       ::= HornClause:c
 
 HornClause        ::= HeadLiteral:h IF BodyLiterals:bls DOT
                    {:                      
-                      RESULT = new HornClause(h,scala.collection.JavaConversions.asScalaBuffer(bls).toList()); 
+                      RESULT = new HornClause(h,scala.jdk.javaapi.CollectionConverters.asScala(bls).toList()); 
                    :}
                    ;
 
@@ -191,17 +191,17 @@ BodyLiterals      ::= BodyLiteral: b
 RelationVariable  ::= ID:id LPAREN Parameters:ps RPAREN
                    {:
                       parser.relVarCount += 1;
-                      RESULT = new RelVar(id, scala.collection.JavaConversions.asScalaBuffer(ps).toList()); 
+                      RESULT = new RelVar(id, scala.jdk.javaapi.CollectionConverters.asScala(ps).toList()); 
                    :}
                    | ID:id ARMC_PARAMS_S Parameters:ps ARMC_PARAMS_E
                    {:
                       parser.relVarCount += 1;
-                      RESULT = new RelVar(id, scala.collection.JavaConversions.asScalaBuffer(ps).toList()); 
+                      RESULT = new RelVar(id, scala.jdk.javaapi.CollectionConverters.asScala(ps).toList()); 
                    :}
                    |  ID:id
                    {:
                       parser.relVarCount += 1;
-                      RESULT = new RelVar(id, scala.collection.JavaConversions.asScalaBuffer(new ArrayList()).toList());
+                      RESULT = new RelVar(id, scala.jdk.javaapi.CollectionConverters.asScala(new ArrayList()).toList());
                    :}
                    ;
 

--- a/src/main/scala/lazabs/horn/parser/HornReader.scala
+++ b/src/main/scala/lazabs/horn/parser/HornReader.scala
@@ -56,6 +56,7 @@ import ap.parameters.{ParserSettings, PreprocessingSettings, Param}
 import scala.collection.{Map => CMap}
 import scala.collection.mutable.{HashMap => MHashMap, ArrayBuffer,
                                  HashSet => MHashSet, LinkedHashSet}
+import scala.jdk.CollectionConverters._
 
 object HornReader {
   def apply(inputStream: InputStream): Seq[HornClause] = {
@@ -63,8 +64,7 @@ object HornReader {
     val lexer = new HornLexer(in)
     val parser = new Parser(lexer)
     val tree = parser.parse()
-    (scala.collection.JavaConversions.asScalaBuffer(
-       tree.value.asInstanceOf[java.util.List[HornClause]]))
+    tree.value.asInstanceOf[java.util.List[HornClause]].asScala.toSeq
   }
 
   def fromSMT(fileName: String) : Seq[HornClause] = {
@@ -350,7 +350,7 @@ class SMTHornReader protected[parser] (
           }
         }
 
-        val newOrder = oriSignature.order extendPred newPreds
+        val newOrder = oriSignature.order extendPred newPreds.toSeq
 
         (UniformSubstVisitor(oriF, unintPredMapping),
          unintPredicates, oriSignature updateOrder newOrder)
@@ -728,7 +728,7 @@ class SMTHornReader protected[parser] (
       def existentialiseAtom(a : Atom) : IAtom = {
         val existConsts = createExistentialConstants(a.size)
 
-        implicit val _ = order
+        implicit val _order: TermOrder = order
         import TerForConvenience._
 
         addAssertion(a === (for (IConstant(c) <- existConsts) yield c))
@@ -757,6 +757,6 @@ class SMTHornReader protected[parser] (
 
     reset
 
-    resClauses
+    resClauses.toSeq
   }
 }

--- a/src/main/scala/lazabs/horn/preprocessor/ArgumentExpander.scala
+++ b/src/main/scala/lazabs/horn/preprocessor/ArgumentExpander.scala
@@ -138,8 +138,8 @@ abstract class ArgumentExpander extends HornPreprocessor {
 
             for (reconstr <- oldArgReconstr) {
               // in that case we can remove the old argument
-              solSubst.reduceToSize(solSubst.size - 1)
-              newSorts.reduceToSize(newSorts.size - 1)
+              solSubst.remove(solSubst.size - 1)
+              newSorts.remove(newSorts.size - 1)
               argMapping -= argNum
               cexArgs(cexArgs.size - 1) =
                 IExpression.shiftVars(reconstr, newSorts.size)
@@ -157,9 +157,9 @@ abstract class ArgumentExpander extends HornPreprocessor {
       }
 
       if (changed) {
-        val newPred = MonoSortedPredicate(pred.name + "_exp", newSorts)
-        newPreds       .put(pred,    (newPred, addedArgs, argMapping.toMap))
-        predBackMapping.put(newPred, (pred, solSubst.toList, cexArgs))
+        val newPred = MonoSortedPredicate(pred.name + "_exp", newSorts.toSeq)
+        newPreds       .put(pred,    (newPred, addedArgs.toSeq, argMapping.toMap))
+        predBackMapping.put(newPred, (pred, solSubst.toList, cexArgs.toSeq))
       }
     }
 
@@ -195,7 +195,7 @@ abstract class ArgumentExpander extends HornPreprocessor {
                 newArgs += t
                 for ((newArgSpecs, oldArgReconstr) <- maybeArgs) {
                   if (oldArgReconstr.isDefined)
-                    newArgs.reduceToSize(newArgs.size - 1)
+                    newArgs.remove(newArgs.size - 1)
 
                   val subst = (List(t), 1)
                   for ((s, sort, name) <- newArgSpecs) {
@@ -214,7 +214,7 @@ abstract class ArgumentExpander extends HornPreprocessor {
                 }
               }
 
-              IAtom(newPred, newArgs)
+              IAtom(newPred, newArgs.toSeq)
             }
             case None =>
               a

--- a/src/main/scala/lazabs/horn/preprocessor/ConstraintSimplifier.scala
+++ b/src/main/scala/lazabs/horn/preprocessor/ConstraintSimplifier.scala
@@ -499,7 +499,7 @@ class ConstraintSimplifier extends HornPreprocessor {
     case IConstant(c) =>
       Some(Map(c -> IdealInt.ONE))
     case ITimes(coeff, t) =>
-      for (m <- asLinearComb(t)) yield m.mapValues(_ * coeff)
+      for (m <- asLinearComb(t)) yield m.mapValues(_ * coeff).toMap
     case IPlus(s, t) =>
       for (m1 <- asLinearComb(s); m2 <- asLinearComb(t)) yield {
         m1 ++ (for ((c, coeff) <- m2.iterator)
@@ -548,7 +548,7 @@ class ConstraintSimplifier extends HornPreprocessor {
     }
 
     if (changed)
-      Some(newConjuncts)
+      Some(newConjuncts.toSeq)
     else
       None
   }

--- a/src/main/scala/lazabs/horn/preprocessor/DefaultPreprocessor.scala
+++ b/src/main/scala/lazabs/horn/preprocessor/DefaultPreprocessor.scala
@@ -194,7 +194,7 @@ class DefaultPreprocessor extends HornPreprocessor {
                         (System.currentTimeMillis - startTime))
     Console.err.println
 
-    (curClauses, curHints, new ComposedBackTranslator(translators.reverse))
+    (curClauses, curHints, new ComposedBackTranslator(translators.reverse.toSeq))
   }
 
 }

--- a/src/main/scala/lazabs/horn/preprocessor/HeapExpander.scala
+++ b/src/main/scala/lazabs/horn/preprocessor/HeapExpander.scala
@@ -156,9 +156,9 @@ class HeapExpander(val name : String,
       }
 
       if (changed) {
-        val newPred = MonoSortedPredicate(pred.name + "_exp", newSorts)
-        newPreds       .put(pred,    (newPred, addedArgs, argMapping.toMap))
-        predBackMapping.put(newPred, (pred, solSubst.toList, cexArgs))
+        val newPred = MonoSortedPredicate(pred.name + "_exp", newSorts.toSeq)
+        newPreds       .put(pred,    (newPred, addedArgs.toSeq, argMapping.toMap))
+        predBackMapping.put(newPred, (pred, solSubst.toList, cexArgs.toSeq))
       }
     }
 
@@ -205,7 +205,7 @@ class HeapExpander(val name : String,
                 }
               }
 
-              IAtom(newPred, newArgs)
+              IAtom(newPred, newArgs.toSeq)
             }
             case None =>
               a

--- a/src/main/scala/lazabs/horn/symex/DepthFirstForwardSymex.scala
+++ b/src/main/scala/lazabs/horn/symex/DepthFirstForwardSymex.scala
@@ -58,7 +58,7 @@ class DepthFirstForwardSymex[CC](clauses: Iterable[CC])(
     unitClauseDB add (fact, parents = (factToNormClause(fact), Nil)) // add each fact to the stack
     val possibleChoices = clausesWithRelationInBody(fact.rs)
     val choiceQueue     = new MQueue[NormClause]
-    choiceQueue.enqueue(possibleChoices: _*)
+    choiceQueue.enqueueAll(possibleChoices)
     choicesStack push choiceQueue
   }
 
@@ -101,7 +101,7 @@ class DepthFirstForwardSymex[CC](clauses: Iterable[CC])(
           "Warning: new unit clause has no clauses to resolve against " + clause)
       case _ => // a decision point
         val choiceQueue = new MQueue[NormClause]
-        choiceQueue.enqueue(possibleChoices: _*)
+        choiceQueue.enqueueAll(possibleChoices)
         choicesStack push choiceQueue
     }
   }

--- a/src/main/scala/lazabs/horn/symex/UnitClauseDB.scala
+++ b/src/main/scala/lazabs/horn/symex/UnitClauseDB.scala
@@ -31,15 +31,7 @@ package lazabs.horn.symex
 import lazabs.horn.bottomup.{NormClause, RelationSymbol}
 import ap.terfor.preds.Predicate
 
-import scala.collection.{AbstractSeq, IndexedSeqLike}
-import scala.collection.mutable.{
-  ListBuffer,
-  ArrayBuffer => MArrayBuffer,
-  HashMap => MHashMap,
-  HashSet => MHashSet,
-  LinkedHashSet => MLinkedHashSet,
-  Stack => MStack
-}
+import scala.collection.mutable.{HashMap => MHashMap, Stack => MStack}
 
 /**
  * Class to keep track of CUCs

--- a/src/main/scala/lazabs/nts/FlataWrapper.scala
+++ b/src/main/scala/lazabs/nts/FlataWrapper.scala
@@ -46,6 +46,8 @@ import verimag.flata_backend.BackEnd
 import verimag.flata_backend.Closure
 import verimag.flata_backend.Loop
 
+import scala.jdk.CollectionConverters._
+
 object AccelerationStrategy extends Enumeration {
   type AccelerationStrategy = Value
   val PRECISE, UNDER_APPROX, OVER_APPROX = Value
@@ -96,10 +98,10 @@ object FlataWrapper {
     var table = new nts.parser.VarTable(null)
     val ntsForms = exps.map(ll => ll.map(Eldarica2Nts(_)))
     val variables = ntsForms.map(x => x.map(_._2)).reduceLeft(_++_).reduceLeft(_++_)
-    val disjunctive = scala.collection.JavaConversions.seqAsJavaList(ntsForms.map(x => (new Loop(scala.collection.JavaConversions.seqAsJavaList(x.map(_._1)))).asInstanceOf[acceleration.ILoop]))
+    val disjunctive = ntsForms.map(x => (new Loop(x.map(_._1.asInstanceOf[nts.interf.base.IExpr]).asJava)).asInstanceOf[acceleration.ILoop]).asJava
     val prefixForms = prefix.map(Eldarica2Nts(_))
     val prefixVars = prefixForms.map(_._2).reduceLeft(_++_)
-    val pref = scala.collection.JavaConversions.seqAsJavaList(prefixForms.map(_._1).map(_.asInstanceOf[nts.interf.base.IExpr]))
+    val pref = prefixForms.map(_._1).map(_.asInstanceOf[nts.interf.base.IExpr]).asJava
     (variables ++ prefixVars).foreach {declareInt(table,_)}
     ntsForms.map(x => x.map(_._1)).reduceLeft(_++_).foreach(_.semanticChecks(table))
     prefixForms.map(_._1).foreach(_.semanticChecks(table))

--- a/src/main/scala/lazabs/prover/PrincessAPI.scala
+++ b/src/main/scala/lazabs/prover/PrincessAPI.scala
@@ -98,7 +98,7 @@ case class Tree[D](d : D, children : List[Tree[D]]) {
     val todo = new ArrayStack[Tree[D]]
     todo push Tree.this
     def hasNext = !todo.isEmpty
-    def next = {
+    def next() = {
       val Tree(data, children) = todo.pop
       todo ++= children
       data
@@ -705,7 +705,7 @@ abstract class AbstractPrincessAPI extends PrincessAPI {
 
     def simplifier = new PredElimSimplifier(booleanVars.toSet, select, store)
 
-    for (intTree <- treeInterpolate(andTree, constants, booleanVars)) yield {
+    for (intTree <- treeInterpolate(andTree, constants, booleanVars.toSeq)) yield {
       (for ((Some(l), f) <- (labelTree zip intTree).toSeq.iterator)
        yield (l -> simplifier(f))).toMap
     }

--- a/src/main/scala/lazabs/upp/RelyGuarantee.scala
+++ b/src/main/scala/lazabs/upp/RelyGuarantee.scala
@@ -233,7 +233,7 @@ object RelyGuarantee {
         //----------------------------------------------------------------------------------------
         case UppTransition(dest, action, assigns, guard) =>
             UppTransition(dest, action, assigns, shortCircuit(Conjunction(chansGuard,guard)))
-      }))
+      }).toMap)
     }
     individualClauses(uppaal.copy(automata = newAutomata, functions = uppaal.functions ++ newFunctions), toAbs)
   }

--- a/src/main/scala/lazabs/utils/Manip.scala
+++ b/src/main/scala/lazabs/utils/Manip.scala
@@ -205,7 +205,7 @@ object Manip {
   def substitute(original: Map[CFGVertex,Set[CFGAdjacent]], replace: Map[Variable,Expression]): Map[CFGVertex,Set[CFGAdjacent]] = {
     original.mapValues {
       s => s.map(adj => CFGAdjacent(substitute(adj.label,replace),adj.to))
-    }
+    }.toMap
   }
   /**
    * inputs a formula and puts version number for variables


### PR DESCRIPTION
Porting Eldarica to Scala 2.13.12.

The port is largely done. Not all regression tests pass. I will investigate these and also check whether there are any performance regressions before unmarking as draft. 

Most of the changes are a result of three breaking API changes from the standard library:

- buffer collections no longer conform to the `Seq` interface
- some `Map` operations return a `MapView`, which then does not conform to the `Map` type, and needs to be forced to evaluate
- the Scala <-> Java collection converters API completely changed

and differences in implicit resolution and the need to specify some types for implicits. 

Tests status:

- :heavy_check_mark: `sbt test`
- :heavy_check_mark: regression: `horn-smt-lib`
- :x: regression: `horn-prolog`
- :heavy_check_mark: regression: `horn-abstract`
- :heavy_check_mark: regression: `horn-accel`
- :gear: regression: `horn-arrays`: fails due to a type mismatch, I know how to fix this, but need to check
- :heavy_check_mark: regression: `horn-adt`
- :heavy_check_mark: regression: `horn-bv`
- :heavy_check_mark: regression: `horn-hcc`
- :heavy_check_mark: regression: `horn-hcc-2`
- :heavy_check_mark: regression: `nts`
- :heavy_check_mark: regression: `horn-quantifiers`
- :heavy_check_mark: regression: `horn-heap`
- :heavy_check_mark: regression: `special`
- :heavy_check_mark: regression: `api`
- :heavy_check_mark: regression: `horn-smt-lib-symex`

For `horn-prolog`, some results are returned, but I have not investigated whether the results are really incorrect or just different correct answers. Someone more familiar with the tests may have a better time investigating this.

Any feedback or help is welcome :)