### PR TITLE
[Symex] Only generate counterexample when the user asks for it

### DIFF
--- a/src/main/scala/lazabs/horn/HornWrapper.scala
+++ b/src/main/scala/lazabs/horn/HornWrapper.scala
@@ -629,6 +629,7 @@ class SymexHornWrapper(unsimplifiedClauses   : Seq[Clause],
           "--------------------------------------")
 
       symex.printInfo = lazabs.GlobalParameters.get.log
+      symex.generateCounterExample = lazabs.GlobalParameters.get.plainCEX || lazabs.GlobalParameters.get.simplifiedCEX
       symex.solve()
     }
 

--- a/src/main/scala/lazabs/horn/symex/Symex.scala
+++ b/src/main/scala/lazabs/horn/symex/Symex.scala
@@ -56,6 +56,10 @@ abstract class Symex[CC](iClauses:    Iterable[CC])(
   import Symex._
 
   var printInfo = false
+
+  // This might be set to true in SymexHornWrapper
+  var generateCounterExample = false
+
   def printInfo(s : String, newLine : Boolean = true) : Unit = {
     if (printInfo)
       print(s + (if (newLine) "\n" else ""))
@@ -227,7 +231,11 @@ abstract class Symex[CC](iClauses:    Iterable[CC])(
           val proverStatus = checkFeasibility(newElectron.constraint)
           if (hasContradiction(newElectron, proverStatus)) { // false :- true
             unitClauseDB.add(newElectron, (nucleus, electrons))
-            result = Right(buildCounterExample(newElectron))
+            if (generateCounterExample) {
+              result = Right(buildCounterExample(newElectron))
+            } else {
+              result = Right(DagEmpty)
+            }
           } else if (constraintIsFalse(newElectron, proverStatus)) {
             printInfo("")
             handleFalseConstraint(nucleus, electrons)
@@ -277,7 +285,11 @@ abstract class Symex[CC](iClauses:    Iterable[CC])(
                 } else toUnitClause(clause)
               unitClauseDB.add(cuc, (clause, Nil))
               if (hasContradiction(cuc, checkFeasibility(cuc.constraint))) {
-                result = Right(buildCounterExample(cuc))
+                if (generateCounterExample) {
+                  result = Right(buildCounterExample(cuc))
+                } else {
+                  result = Right(DagEmpty)
+                }
               }
             }
             if (result == null) { // none of the assertions failed, so this is SAT


### PR DESCRIPTION
This commit reduces the time to get an answer when the result is unsat. Generating a counterexample can also cause a stackoverflow in some cases.

Results below for running the symex engine on this file: https://github.com/chc-comp/aeval-unsafe/blob/de86ef1051b1c521b8c04f5c30c13f417d339529/s_split_01.smt2

**Before changes:**
% command time ./eld -sym:bfs s_split_01_equivalent.smt2
unsat
       72,82 real        93,15 user         1,98 sys

**After changes:**
% command time ./eld -sym:bfs s_split_01_equivalent.smt2               
unsat
        3,61 real         6,94 user         0,27 sys
