### PR TITLE
[Symex] Fix problem which might occur in hasContradiction when using backward resolution

### DIFF
--- a/src/main/scala/lazabs/horn/symex/Symex.scala
+++ b/src/main/scala/lazabs/horn/symex/Symex.scala
@@ -407,7 +407,7 @@ abstract class Symex[CC](iClauses:    Iterable[CC])(
   // true if cuc = "FALSE :- c" and c is satisfiable, false otherwise.
   private def hasContradiction(cuc:          UnitClause,
                                proverStatus: ProverStatus.Value): Boolean = {
-    ((cuc.rs.pred == HornClauses.FALSE) || (!cuc.isPositive)) &&
+    ((cuc.rs.pred == HornClauses.FALSE) || (!cuc.isPositive && cuc.rs.pred == HornClauses.FALSE)) &&
     (proverStatus match { // check if cuc constraint is satisfiable
       case ProverStatus.Valid | ProverStatus.Sat     => true
       case ProverStatus.Invalid | ProverStatus.Unsat => false


### PR DESCRIPTION
In the previous code "False :- P(..) /\ c" was considered to be a contradiction if c was satisfiable. It did not account for the predicate P in the body. The code now matches the comment above the function.