### PR TITLE
Make `eld` command robust against spaces in current dir

### DIFF
--- a/eld
+++ b/eld
@@ -6,8 +6,8 @@ else
     pathCmd="realpath"
 fi
 
-BASEDIR=`dirname $($pathCmd $0)`
+BASEDIR=`dirname "$($pathCmd $0)"`
 
-. $BASEDIR/eldEnv
+. "$BASEDIR/eldEnv"
 
 exec $LAZABS_CMD lazabs.Main "$@"


### PR DESCRIPTION
Only tested on Linux.