### PR TITLE
Native image fixes

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up sbt
       uses: sbt/setup-sbt@v1
     - name: Build
-      run: sbt assembly
+      run: sbt nativeImage
     - name: UnitTests
       run: sbt test
     - name: Test

--- a/build.sbt
+++ b/build.sbt
@@ -186,14 +186,23 @@ lazy val root = (project in file(".")).
 //
     resolvers += "uuverifiers" at "https://eldarica.org/maven/",
     libraryDependencies += "uuverifiers" %% "princess" % "nightly-SNAPSHOT",
+
+    // needed by flata for native-image
+    resolvers += "XypronRelease" at "https://www.xypron.de/repository",
+    libraryDependencies += "org.gnu.glpk" % "glpk-java" % "1.12.0",
 //
-    nativeImageInstalled := true,
+    // nativeImageInstalled := true,
     // point to your GraalVM (recommended via env var)
     //nativeImageGraalHome := file(sys.env("GRAALVM_HOME")).toPath,
 
     nativeImageOptions ++= Seq(
       "--no-fallback",
-      "-H:+ReportExceptionStackTraces"
+      "-H:+ReportExceptionStackTraces",
+      "--allow-incomplete-classpath",
+      "--initialize-at-run-time=org.gnu.glpk.glp_prob",
+      "--initialize-at-run-time=ap.basetypes.BigComplex$",
+      "--initialize-at-build-time=verimag.flata.presburger.Relation",
+      "--initialize-at-build-time=nts.parser.VarTable"
     ),
 
     nativeImageAgentMerge := true

--- a/src/main/resources/META-INF/native-image/uuverifiers/eldarica/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/uuverifiers/eldarica/reflect-config.json
@@ -1,0 +1,64 @@
+[
+  {
+    "name": "[Lap.parser.IFormula;"
+  },
+  {
+    "name": "[Lap.parser.ITerm;"
+  },
+  {
+    "name": "[Lap.terfor.conjunctions.Conjunction;"
+  },
+  {
+    "name": "[Lap.terfor.conjunctions.Quantifier$ALL$;"
+  },
+  {
+    "name": "[Lap.terfor.conjunctions.Quantifier$EX$;"
+  },
+  {
+    "name": "[Lap.terfor.linearcombination.LinearCombination;"
+  },
+  {
+    "name": "[Lap.terfor.preds.Atom;"
+  },
+  {
+    "name": "[Lscala.Function1;"
+  },
+  {
+    "name": "[Lscala.Option;"
+  },
+  {
+    "name": "[Lscala.Tuple2;"
+  },
+  {
+    "name": "[Lscala.Tuple3;"
+  },
+  {
+    "name": "ap.theories.strings.SeqStringTheoryBuilder",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "java.util.HashSet",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "java.util.HashMap",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "java.util.ArrayList",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "java.util.LinkedHashSet",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  }
+]


### PR DESCRIPTION
Generated `src/main/resources/META-INF/native-image/uuverifiers/eldarica/reflect-config.json` using the GraalVM tracing agent by commenting out `set -e` in `regression-tests/runalldirs`, then:
```
cd regression-tests
export JAVA_TOOL_OPTIONS="-agentlib:native-image-agent=config-merge-dir=../src/main/resources/META-INF/native-image/uuverifiers/eldarica/"
./runtests
unset JAVA_TOOL_OPTIONS
```

Also adjusted the options used for native-image inside build.sbt for the build to succeed.